### PR TITLE
fix: year-ladder calculation + add Energy dashboard sensor

### DIFF
--- a/custom_components/state_grid_info/sensor.py
+++ b/custom_components/state_grid_info/sensor.py
@@ -567,6 +567,8 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
         """Process Qinglong script data."""
         try:
             dayList_ori = payload.get("dayList", [])
+            # Extract totalEleNum from MQTT payload for accurate year-ladder calculation
+            total_ele_num = float(payload.get("totalEleNum", 0))
             
             # 重写日结构
             dayList7 = []
@@ -586,6 +588,7 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
                 "date": payload.get("date", ""),
                 "balance": float(payload.get("sumMoney", 0)),
                 "dayList": dayList7,
+                "totalEleNum": total_ele_num,
             }
             
             # 临时保存当前的 self.data
@@ -605,8 +608,8 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
             monthList_ori = payload.get("monthList", [])
             monthList = self._process_month_data(dayList, monthList_ori)
             
-            # 处理年数据
-            yearList = self._process_year_data(monthList)
+            # 处理年数据，传入 totalEleNum 确保年累计电量准确
+            yearList = self._process_year_data(monthList, total_ele_num)
             
             return {
                 "date": payload.get("date", ""),
@@ -646,6 +649,30 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
         except Exception as ex:
             _LOGGER.error("Error calculating daily cost: %s", ex)
             return day_list
+
+    def _get_year_accumulated(self, ladder_year, year_ladder_start_date, current_day):
+        """Get accumulated electricity usage for the current ladder year.
+        
+        Priority: totalEleNum (MQTT) > yearList (persisted) > dayList sum.
+        """
+        year_accumulated = 0
+        if self.data is None:
+            return year_accumulated
+        
+        total_ele = self.data.get("totalEleNum", 0)
+        if total_ele > 0:
+            return total_ele
+        
+        year_list = self.data.get("yearList", [])
+        ladder_year_str = str(ladder_year)
+        for yr in year_list:
+            if yr.get("year") == ladder_year_str and yr.get("yearEleNum", 0) > 0:
+                return yr["yearEleNum"]
+        
+        for data in self.data.get("dayList", []):
+            if data["day"] >= year_ladder_start_date and data["day"] <= current_day:
+                year_accumulated += data["dayEleNum"]
+        return year_accumulated
 
     def _calculate_cost_by_standard(self, day_data, standard):
         """Calculate cost based on specific billing standard."""
@@ -689,14 +716,10 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
                 year_ladder_end_date = f"{ladder_year + 1}-{year_ladder_start[:2]}-{year_ladder_start[2:]}"
                 
                 # 计算累计用电量
-                year_accumulated = 0
-                
-                if self.data is not None:
-                    for data in self.data.get("dayList", []):
-                        # 计算年累计用电量：从年阶梯起始日期到当前日期
-                        if (data["day"] >= year_ladder_start_date and 
-                            data["day"] <= current_day):
-                            year_accumulated += data["dayEleNum"]
+                # 优先使用 MQTT totalEleNum / yearList（完整累计），fallback 日累计
+                year_accumulated = self._get_year_accumulated(
+                    ladder_year, year_ladder_start_date, current_day
+                )
                 
                 # 根据累计用电量计算阶梯电价
                 if year_accumulated <= ladder_level_1:
@@ -783,14 +806,9 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
                 year_ladder_end_date = f"{ladder_year + 1}-{year_ladder_start[:2]}-{year_ladder_start[2:]}"
                 
                 # 计算累计用电量
-                year_accumulated = 0
-                
-                if self.data is not None:
-                    for data in self.data.get("dayList", []):
-                        # 计算年累计用电量：从年阶梯起始日期到当前日期
-                        if (data["day"] >= year_ladder_start_date and 
-                            data["day"] <= current_day):
-                            year_accumulated += data["dayEleNum"]
+                year_accumulated = self._get_year_accumulated(
+                    ladder_year, year_ladder_start_date, current_day
+                )
                 
                 # 根据累计用电量确定当前阶梯
                 if year_accumulated <= ladder_level_1:
@@ -1282,8 +1300,14 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Error calculating month data: %s", ex)
             return None
 
-    def _process_year_data(self, month_list):
-        """Process and calculate yearly data from monthly data."""
+    def _process_year_data(self, month_list, current_year_total=0.0):
+        """Process and calculate yearly data from monthly data.
+        
+        Args:
+            month_list: List of monthly data dicts.
+            current_year_total: If > 0, use as the authoritative yearEleNum
+                for the current year (e.g., from MQTT totalEleNum).
+        """
         try:
             year_map = {}  # 用于按年份暂存数据
             
@@ -1307,6 +1331,14 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
                 year_map[year]["yearPPq"] += month_data.get("monthPPq", 0)
                 year_map[year]["yearNPq"] += month_data.get("monthNPq", 0)
                 year_map[year]["yearVPq"] += month_data.get("monthVPq", 0)
+            
+            # If totalEleNum is available from MQTT, use it as the authoritative
+            # year total instead of summing months (dayList may be incomplete)
+            if current_year_total > 0:
+                from datetime import datetime as _dt
+                current_year = _dt.now().strftime("%Y")
+                if current_year in year_map:
+                    year_map[current_year]["yearEleNum"] = current_year_total
             
             # 四舍五入到两位小数
             year_list = []
@@ -1620,10 +1652,9 @@ class StateGridInfoSensor(SensorEntity):
                 year_ladder_start_date = f"{ladder_year}-{year_ladder_start[:2]}-{year_ladder_start[2:]}"
                 
                 # 计算年累计用电量
-                year_accumulated = 0
-                for data in day_list:
-                    if data["day"] >= year_ladder_start_date and data["day"] <= current_day:
-                        year_accumulated += data["dayEleNum"]
+                year_accumulated = self.coordinator._get_year_accumulated(
+                    ladder_year, year_ladder_start_date, current_day
+                )
                 
                 # 确定当前阶梯档
                 if year_accumulated <= ladder_level_1:

--- a/custom_components/state_grid_info/sensor.py
+++ b/custom_components/state_grid_info/sensor.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import datetime, timedelta
 import paho.mqtt.client as mqtt
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -43,14 +43,16 @@ async def async_setup_entry(
     await coordinator.async_load_storage()
     await coordinator.async_config_entry_first_refresh()
     
-    # 创建传感器实体，确保实体ID包含用户的电力户号
+    # 创建传感器实体
     sensor = StateGridInfoSensor(coordinator, config)
+    energy_sensor = StateGridCumulativeEnergySensor(coordinator, config)
+    entities = [sensor, energy_sensor]
     
     # 存储实体以便在卸载时访问
     if DOMAIN in hass.data and entry.entry_id in hass.data[DOMAIN]:
-        hass.data[DOMAIN][entry.entry_id]["entities"] = [sensor]
+        hass.data[DOMAIN][entry.entry_id]["entities"] = entities
     
-    async_add_entities([sensor], True)
+    async_add_entities(entities, True)
 
 
 class StateGridInfoDataCoordinator(DataUpdateCoordinator):
@@ -1360,6 +1362,65 @@ class StateGridInfoDataCoordinator(DataUpdateCoordinator):
             return []
 
 
+class StateGridCumulativeEnergySensor(SensorEntity):
+    """Cumulative energy consumption sensor for HA Energy dashboard.
+    
+    Provides a total_increasing energy meter reading suitable for
+    HA's Energy dashboard grid consumption input.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_icon = "mdi:transmission-tower"
+
+    def __init__(self, coordinator, config):
+        """Initialize the cumulative energy sensor."""
+        self.coordinator = coordinator
+        self.config = config
+        consumer_number = config.get(CONF_CONSUMER_NUMBER, "")
+        consumer_name = config.get(CONF_CONSUMER_NAME, "")
+        self._attr_unique_id = f"state_grid_{consumer_number}_energy"
+        self._attr_name = f"国家电网 {consumer_number} 累计用电"
+        self._consumer_number = consumer_number
+        self._consumer_name = consumer_name
+
+    @property
+    def device_info(self):
+        """Return device info (same device as balance sensor)."""
+        consumer_name = ""
+        if self.coordinator.data and "consumer_name" in self.coordinator.data:
+            consumer_name = self.coordinator.data.get("consumer_name", "")
+        elif self._consumer_name:
+            consumer_name = self._consumer_name
+
+        return {
+            "identifiers": {(DOMAIN, f"state_grid_{self._consumer_number}")},
+            "name": f"国家电网 {self._consumer_number}",
+            "manufacturer": "国家电网",
+            "model": f"户名:{consumer_name}"
+        }
+
+    @property
+    def available(self):
+        """Return if entity is available."""
+        if not self.coordinator.data:
+            return False
+        time_diff = datetime.now() - self.coordinator.last_update_time
+        if time_diff.total_seconds() > 3600:
+            return False
+        return True
+
+    @property
+    def native_value(self):
+        """Return cumulative energy consumption (kWh)."""
+        if self.coordinator.data:
+            day_list = self.coordinator.data.get("dayList", [])
+            if day_list:
+                return sum(d.get("dayEleNum", 0) for d in day_list)
+        return 0
+
+
 class StateGridInfoSensor(SensorEntity):
     """Representation of a State Grid Info sensor."""
 
@@ -1374,6 +1435,8 @@ class StateGridInfoSensor(SensorEntity):
 
         self._attr_name = f"国家电网 {consumer_number}"
         self._attr_native_unit_of_measurement = "元"
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._consumer_number = consumer_number
 
     @property


### PR DESCRIPTION
## Summary

Two fixes for the state_grid_info integration:

### 1. Fix year-ladder calculation using MQTT totalEleNum

**Problem:** `_get_ladder_info` and `_calculate_cost_by_standard` summed `dayList` to calculate year-accumulated usage, but dayList only has ~30-40 days. This caused year-ladder tier to always show tier 1 regardless of actual usage.

**Fix:** Priority chain: MQTT `totalEleNum` → persisted `yearList` → dayList sum (fallback). Extracted into `_get_year_accumulated()` helper to eliminate duplication.

### 2. Add cumulative energy sensor for HA Energy dashboard

**Problem:** HA Energy dashboard requires sensors with `device_class=energy` and `state_class=total_increasing` in kWh. The existing sensor used balance (元) as its state with no device_class/state_class, making it incompatible.

**Fix:**
- New `StateGridCumulativeEnergySensor` entity (device_class=energy, state_class=total_increasing, unit=kWh)
- Existing balance sensor updated (device_class=monetary, state_class=total)
- Both share the same coordinator and device_info

### Changes

1 file: `sensor.py` (+122/-28)
- `_get_year_accumulated()` helper method
- `_process_qinglong_data` extracts totalEleNum
- `_process_year_data` accepts optional current_year_total
- `StateGridCumulativeEnergySensor` class
- Updated `async_setup_entry` to register both entities